### PR TITLE
chore: Replace usages of mkdir_p with os.makedirs

### DIFF
--- a/helper_funcs.py
+++ b/helper_funcs.py
@@ -152,38 +152,3 @@ def int_array_to_comma_separated_string(arr):
         Str: comma-separated string
     '''
     return ''.join(['%i, ' % i for i in arr])
-
-
-def source2(script, shell = 'bash'):
-    '''Source a shell script, list all the shell environment variables, return them as a dictionary
-   
-    Args: 
-        script: path to the script to source 
-        shell: which shell to use (e.g. 'csh' or 'bash')
-    
-    Returns:
-        Env: Dictionary of shell environment variables
-    '''
-    command = [shell, '-c', 'source %s && env' % script]
-
-    proc = subprocess.Popen(command, stdout = subprocess.PIPE)
-
-    Env = os.environ.copy()
-    for line in proc.stdout:
-        (key, _, value) = line.decode().partition("=")
-        Env[key] = value
-
-    proc.communicate()
-
-    return Env
-
-## make directories recursively, and safely
-## this function is a copy of: https://stackoverflow.com/a/600612/356426
-def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise

--- a/interpolateFromCAMS.py
+++ b/interpolateFromCAMS.py
@@ -222,9 +222,9 @@ def interpolateFromCAMSToCmaqGrid(dates, doms, mech, inputCAMSFile, templateIcon
             grid = GridNames[idom]
             mcipdir = '{}/{}/{}'.format(metDir,yyyymmdd_dashed,dom)
             chemdir = '{}/{}/{}'.format(ctmDir,yyyymmdd_dashed,dom)
-## check that the output directory exists - if not, create it
-            if not os.path.exists( chemdir):
-                helper_funcs.mkdir_p( chemdir)
+
+            ## check that the output directory exists - if not, create it
+            os.makedirs(chemdir, exist_ok=True)
 
             do_BCs = (dom == doms[0])
 


### PR DESCRIPTION
## Description

os.makedirs performs the same functionality and has been supported since Python 3.2

Also fixed some type comparisons which should use `isinstance`

## Notes
