### PR TITLE
Use USGS land use categories

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: data/geog
-          key: ${{ runner.os }}
+          key: geog-data-${{ runner.os }}
       - name: Download and extract geography data
         if: steps.cache-geog.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,16 +44,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: data/geog
-          key: geog-data-${{ runner.os }}
+          key: geog-data-${{ hashFiles('scripts/download-geog.sh') }}
       - name: Download and extract geography data
         if: steps.cache-geog.outputs.cache-hit != 'true'
         run: |
-          mkdir -p data/geog
-          wget -qN https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz -P data/geog
-          wget -qN https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_10m.tar.bz2 -P data/geog
-          tar -xf data/geog/geog_low_res_mandatory.tar.gz -C data/geog
-          tar -xf data/geog/landuse_10m.tar.bz2 -C data/geog/WPS_GEOG_LOW_RES
-          mv data/geog/WPS_GEOG_LOW_RES data/geog/WPS_GEOG
+          ./scripts/download-geog.sh --low-res
       - name: Run test
         run: |
           # Update the namelist.wps file to use the low resolution data

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,23 +50,24 @@ jobs:
         run: |
           mkdir -p data/geog
           wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz -P data/geog
-          wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s.tar.bz2 -P data/geog
-          tar -xvzf data/geog/geog_low_res_mandatory.tar.gz -C data/geog
-          tar -xvzf data/geog/landuse_30s.tar.bz2 -C data/geog/WPS_GEOG_LOW_RES
+          wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_10m.tar.bz2 -P data/geog
+          tar -xf data/geog/geog_low_res_mandatory.tar.gz -C data/geog
+          tar -xvf data/geog/landuse_10m.tar.bz2 -C data/geog/WPS_GEOG_LOW_RES
+          mv data/geog/WPS_GEOG_LOW_RES data/geog/WPS_GEOG
       - name: Run test
         run: |
           # Update the namelist.wps file to use the low resolution data
-          sed -i "s/geog_data_res.*/geog_data_res = 'usgs_30s+lowres',/g" templates/aust-test/namelist.wps
+          sed -i "s/geog_data_res.*/geog_data_res = 'usgs_10m+lowres',/g" templates/aust-test/namelist.wps
           # Run setup_for_wrf.py
           docker run --rm \
             -v ${{ github.workspace }}:/project \
-            -v ${{ github.workspace }}/data/geog/WPS_GEOG_LOW_RES:/opt/wrf/geog \
+            -v ${{ github.workspace }}/data/geog:/opt/wrf/geog \
             setup_wrf \
             python setup_for_wrf.py -c config.docker.json
           # Run WRF
           docker run --rm \
             -v ${{ github.workspace }}:/project \
-            -v ${{ github.workspace }}/data/geog/WPS_GEOG_LOW_RES:/opt/wrf/geog \
+            -v ${{ github.workspace }}/data/geog/WPS_GEOG:/opt/wrf/geog \
             setup_wrf \
             data/runs/aust-test/main.sh
       # The WRF directory contains filenames with : in them, which are not supported by upload-artifact

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,12 +49,14 @@ jobs:
         if: steps.cache-geog.outputs.cache-hit != 'true'
         run: |
           mkdir -p data/geog
-          curl "https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz" -o data/geog/geog_low_res_mandatory.tar.gz
+          wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz -P data/geog
+          wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s.tar.bz2 -P data/geog
           tar -xvzf data/geog/geog_low_res_mandatory.tar.gz -C data/geog
+          tar -xvzf data/geog/landuse_30s.tar.bz2 -C data/geog/WPS_GEOG_LOW_RES
       - name: Run test
         run: |
           # Update the namelist.wps file to use the low resolution data
-          sed -i "s/geog_data_res.*/geog_data_res = 'lowres',/g" templates/aust-test/namelist.wps
+          sed -i "s/geog_data_res.*/geog_data_res = 'usgs_30s+lowres',/g" templates/aust-test/namelist.wps
           # Run setup_for_wrf.py
           docker run --rm \
             -v ${{ github.workspace }}:/project \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,10 @@ jobs:
         if: steps.cache-geog.outputs.cache-hit != 'true'
         run: |
           mkdir -p data/geog
-          wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz -P data/geog
-          wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_10m.tar.bz2 -P data/geog
+          wget -qN https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz -P data/geog
+          wget -qN https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_10m.tar.bz2 -P data/geog
           tar -xf data/geog/geog_low_res_mandatory.tar.gz -C data/geog
-          tar -xvf data/geog/landuse_10m.tar.bz2 -C data/geog/WPS_GEOG_LOW_RES
+          tar -xf data/geog/landuse_10m.tar.bz2 -C data/geog/WPS_GEOG_LOW_RES
           mv data/geog/WPS_GEOG_LOW_RES data/geog/WPS_GEOG
       - name: Run test
         run: |
@@ -61,7 +61,7 @@ jobs:
           # Run setup_for_wrf.py
           docker run --rm \
             -v ${{ github.workspace }}:/project \
-            -v ${{ github.workspace }}/data/geog:/opt/wrf/geog \
+            -v ${{ github.workspace }}/data/geog/WPS_GEOG:/opt/wrf/geog \
             setup_wrf \
             python setup_for_wrf.py -c config.docker.json
           # Run WRF

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,6 @@ virtual-environment:  ## update virtual environment, create a new one if it does
 data/geog: ## Download static geography data
 	mkdir -p data/geog
 	curl https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz -o data/geog/geog_high_res_mandatory.tar.gz
+	curl https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s_with_lakes.tar.bz2 -o data/geog/landuse_30s_with_lakes.tar.bz2
 	tar -xvzf data/geog/geog_high_res_mandatory.tar.gz -C data/geog
+	tar -xvzf data/geog/landuse_30s_with_lakes.tar.bz2 -C data/geog

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,5 @@ virtual-environment:  ## update virtual environment, create a new one if it does
 	poetry install --all-extras
 
 
-data/geog: ## Download static geography data
-	mkdir -p data/geog
-	wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz -P data/geog
-	wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s.tar.bz2 -P data/geog
-	tar -xvzf data/geog/geog_high_res_mandatory.tar.gz -C data/geog
-	tar -xvzf data/geog/landuse_30s.tar.bz2 -C data/geog/WPS_GEOG
+data/geog: scripts/download-geog.sh ## Download static geography data
+	./scripts/download-geog.sh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ virtual-environment:  ## update virtual environment, create a new one if it does
 
 data/geog: ## Download static geography data
 	mkdir -p data/geog
-	curl https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz -o data/geog/geog_high_res_mandatory.tar.gz
-	curl https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s_with_lakes.tar.bz2 -o data/geog/landuse_30s_with_lakes.tar.bz2
+	wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz -P data/geog
+	wget -N https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s.tar.bz2 -P data/geog
 	tar -xvzf data/geog/geog_high_res_mandatory.tar.gz -C data/geog
-	tar -xvzf data/geog/landuse_30s_with_lakes.tar.bz2 -C data/geog
+	tar -xvzf data/geog/landuse_30s.tar.bz2 -C data/geog/WPS_GEOG

--- a/scripts/download-geog.sh
+++ b/scripts/download-geog.sh
@@ -52,7 +52,9 @@ else
   wget -N -nv https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz -P $output_dir
 	wget -N -nv https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s.tar.bz2 -P $output_dir
 	echo "Extracting data to $output_dir/WPS_GEOG..."
-	echo "This may take a few minutes"
+	echo "  This may take a few minutes"
 	tar -xzf $output_dir/geog_high_res_mandatory.tar.gz -C $output_dir
 	tar -xzf $output_dir/landuse_30s.tar.bz2 -C $output_dir/WPS_GEOG
 fi
+
+echo "Completed downloading and extracting WRF geog data."

--- a/scripts/download-geog.sh
+++ b/scripts/download-geog.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Downloads the required WRF Geog data
+#
+# The output will be stored in `data/geog`
+# with the geog data required by WRF being stored in `data/geog/WPS_GEOG`.
+#
+# Required datasets: Defaults + USGS
+
+set -Eeuo pipefail
+
+parse_params() {
+  # default values of variables set from params
+  low_res=0
+
+  while :; do
+    case "${1-}" in
+#    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -l | --low-res) low_res=1 ;; # Download low res data
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  args=("$@")
+
+  return 0
+}
+
+parse_params "$@"
+
+output_dir="data/geog"
+
+mkdir -p $output_dir
+
+if ((low_res)); then
+  echo "Downloading low resolution data"
+  wget -N -nv https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz -P $output_dir
+  wget -N -nv https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_10m.tar.bz2 -P $output_dir
+  tar -xf $output_dir/geog_low_res_mandatory.tar.gz -C $output_dir
+	echo "Extracting data to $output_dir/WPS_GEOG..."
+  tar -xf $output_dir/landuse_10m.tar.bz2 -C $output_dir/WPS_GEOG_LOW_RES
+  if [[ -d $output_dir/WPS_GEOG ]]; then
+    cp -r $output_dir/WPS_GEOG_LOW_RES/* $output_dir/WPS_GEOG/
+    rm -r $output_dir/WPS_GEOG_LOW_RES
+  else
+    mv $output_dir/WPS_GEOG_LOW_RES $output_dir/WPS_GEOG
+  fi
+else
+  echo "Downloading high resolution data"
+  wget -N -nv https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz -P $output_dir
+	wget -N -nv https://www2.mmm.ucar.edu/wrf/src/wps_files/landuse_30s.tar.bz2 -P $output_dir
+	echo "Extracting data to $output_dir/WPS_GEOG..."
+	echo "This may take a few minutes"
+	tar -xzf $output_dir/geog_high_res_mandatory.tar.gz -C $output_dir
+	tar -xzf $output_dir/landuse_30s.tar.bz2 -C $output_dir/WPS_GEOG
+fi

--- a/templates/aust-test/namelist.wps
+++ b/templates/aust-test/namelist.wps
@@ -17,7 +17,7 @@
  j_parent_start    = 200,
  e_we          = 10,
  e_sn          = 10,
- geog_data_res     = 'default','default','default','default',
+ geog_data_res     = 'usgs_lakes+default',
  dx = 10000,
  dy = 10000,
  map_proj =  'lambert',

--- a/templates/aust-test/namelist.wps
+++ b/templates/aust-test/namelist.wps
@@ -17,7 +17,7 @@
  j_parent_start    = 200,
  e_we          = 10,
  e_sn          = 10,
- geog_data_res     = 'usgs+default',
+ geog_data_res     = 'usgs_30s+default',
  dx = 10000,
  dy = 10000,
  map_proj =  'lambert',

--- a/templates/aust-test/namelist.wps
+++ b/templates/aust-test/namelist.wps
@@ -17,7 +17,7 @@
  j_parent_start    = 200,
  e_we          = 10,
  e_sn          = 10,
- geog_data_res     = 'usgs_lakes+default',
+ geog_data_res     = 'usgs+default',
  dx = 10000,
  dy = 10000,
  map_proj =  'lambert',

--- a/templates/aust-test/namelist.wrf
+++ b/templates/aust-test/namelist.wrf
@@ -83,7 +83,7 @@ smooth_option                       = 1,
     sst_update = 1
     sst_skin = 1
     progn = 1,
-    num_land_cat = 21
+    num_land_cat = 24
 /
 
 &fdda                    


### PR DESCRIPTION
# Description

Use USGS 24-category land use data. While diving into the CMAQ code I noticed that there was some modified code that depends on the USGS land use categories

The default landuse data in WRFv4 is now based on MODIS.

Note that the other templates use 10m resolution data when the 30s dataset is freely available. @prayner We should likely update to the higher resolution version in the production domain

# Notes

This is pulling out one of the modifications in #6 to try and make it a bit smaller

