### PR TITLE
Add CR and Jeremy Silver copyright attribution to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,6 +176,8 @@
 
    END OF TERMS AND CONDITIONS
 
+   Copyright 2018-2022 Jeremy Silver
+   Copyright 2024 Climate Resource
    Copyright 2023-present The Superpower Institute
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description

Adds Climate Resource copyright attribution for 2024 to the text of the license. Adds Jeremy Silver copyright attribution which had been missed.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`)

## Notes
