### PR TITLE
Fix build action

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -97,7 +97,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags/v')
         run: |
           TAG_REF="${{ github.event.ref }}"
-          TAG_VERSION=${TAG_REF/"refs\/tags\/"}
+          TAG_VERSION=${TAG_REF#"refs/tags/"}
           if [ "$SETUP_WRF_VERSION" != "$TAG_VERSION" ]; then
             echo "SETUP_WRF_VERSION is $SETUP_WRF_VERSION; expected version is $TAG_VERSION"
             exit 1

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -45,6 +45,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          PACKAGE_VERSION=$(grep -oP '^version = "\K(.+)(?=")' pyproject.toml)
+          echo "version=v$PACKAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -71,7 +76,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            SETUP_WRF_VERSION=${{ steps.meta.outputs.version }}
+            SETUP_WRF_VERSION=${{ steps.version.outputs.version }}
           push: true
           pull: false
           cache-from: type=gha

--- a/changelog/54.fix.md
+++ b/changelog/54.fix.md
@@ -1,0 +1,1 @@
+Fix actions incorrectly populating container image version


### PR DESCRIPTION
## Description

The build action in openmethane broke recently due to (I believe) changes in the ubuntu-latest runner which has been updated to a newer version. This PR is porting the same changes that resolved the issue in the openmethane build action.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
