### PR TITLE
Skip WRF & MCIP if files already exist

### DIFF
--- a/changelog/55.improvement.md
+++ b/changelog/55.improvement.md
@@ -1,0 +1,1 @@
+Skip running WRF and MCIP if results already exist, unless FORCE_WRF env variable is "true"


### PR DESCRIPTION

## Description

As per https://github.com/openmethane/openmethane/issues/120, the WRF/MCIP workflow is time consuming and resource intensive. If a daily run has already been completed and the MCIP results needed by the rest of the system are already available, we should be able to skip re-generating these files.

However, if any files are missing, or we explicitly want to regenerate them, the full script should still run.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
