### PR TITLE
Add FNL file caching

### DIFF
--- a/config/config.docker.full.json
+++ b/config/config.docker.full.json
@@ -29,6 +29,7 @@
   "metem_dir": "${run_dir}/metem",
   "namelist_wps": "${nml_dir}/namelist.wps",
   "namelist_wrf": "${nml_dir}/namelist.wrf",
+  "fnl_cache_path": "/opt/project/data/fnl",
   "geog_data_path": "/opt/project/data/geog/WPS_GEOG",
   "geogrid_tbl": "${wps_dir}/geogrid/GEOGRID.TBL",
   "geogrid_exe": "${wps_dir}/geogrid.exe",

--- a/config/config.docker.json
+++ b/config/config.docker.json
@@ -29,6 +29,7 @@
   "metem_dir": "${run_dir}/metem",
   "namelist_wps": "${nml_dir}/namelist.wps",
   "namelist_wrf": "${nml_dir}/namelist.wrf",
+  "fnl_cache_path": "/opt/project/data/fnl",
   "geog_data_path": "/opt/project/data/geog/WPS_GEOG",
   "geogrid_tbl": "${wps_dir}/geogrid/GEOGRID.TBL",
   "geogrid_exe": "${wps_dir}/geogrid.exe",

--- a/config/config.nci.json
+++ b/config/config.nci.json
@@ -29,6 +29,7 @@
     "metem_dir" : "${run_dir}/metem",
     "namelist_wps" : "${nml_dir}/namelist.wps",
     "namelist_wrf" : "${nml_dir}/namelist.wrf",
+    "fnl_cache_path": null,
     "geog_data_path" : "/g/data/sx70/data/WPS_GEOG_20190418",
     "geogrid_tbl" : "${wps_dir}/geogrid/GEOGRID.TBL",
     "geogrid_exe" : "${wps_dir}/geogrid.exe",

--- a/scripts/setup_for_wrf.py
+++ b/scripts/setup_for_wrf.py
@@ -545,6 +545,7 @@ def run_setup_for_wrf(configfile: str) -> None:
                             FNLfiles = download_gdas_fnl_data(
                                 target_dir=run_dir_with_date,
                                 download_dts=FNLtimes,
+                                cache_path=wrf_config.fnl_cache_path,
                             )
                         linkGribCmds = ["./link_grib.csh"] + FNLfiles
                         ## optionally take a regional subset

--- a/src/setup_runs/wrf/fetch_fnl.py
+++ b/src/setup_runs/wrf/fetch_fnl.py
@@ -22,7 +22,6 @@ from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 N_JOBS = 8
-LOGIN_URL = "https://rda.ucar.edu/cgi-bin/login"
 DATASET_URL = "https://data-osdf.rda.ucar.edu/ncar/rda/d083003/"
 FNL_START_DATE = pytz.UTC.localize(datetime.datetime(2015, 7, 8, 0, 0, 0))
 

--- a/src/setup_runs/wrf/read_config_wrf.py
+++ b/src/setup_runs/wrf/read_config_wrf.py
@@ -86,6 +86,8 @@ class WRFConfig:
     """template namelist for WPS"""
     namelist_wrf: str
     """template namelist for WRF"""
+    fnl_cache_path: str | None
+    """path to store cached FNL files"""
     geog_data_path: str
     """path to the geography data files"""
     geogrid_tbl: str

--- a/tests/unit/test_read_config/test_docker_config_regression.yml
+++ b/tests/unit/test_read_config/test_docker_config_regression.yml
@@ -7,6 +7,7 @@ cleanup_script_template: /opt/project/targets/docker/cleanup_script_template.sh
 delete_metem_files: false
 end_date: 2022-07-23 00:00:00+00:00
 environment_variables_for_substitutions: HOME
+fnl_cache_path: /opt/project/data/fnl
 geo_em_dir: /opt/project/data/runs/aust-test
 geog_data_path: /opt/project/data/geog/WPS_GEOG
 geogrid_exe: /opt/wrf/WPS/geogrid.exe

--- a/tests/unit/test_read_config/test_nci_config_regression.yml
+++ b/tests/unit/test_read_config/test_nci_config_regression.yml
@@ -7,6 +7,7 @@ cleanup_script_template: '{HOME}/openmethane-beta/setup-wrf/targets/nci/cleanup_
 delete_metem_files: false
 end_date: 2022-07-23 00:00:00+00:00
 environment_variables_for_substitutions: HOME
+fnl_cache_path: null
 geo_em_dir: '{HOME}/openmethane-beta/setup-wrf/domains/aust-test'
 geog_data_path: /g/data/sx70/data/WPS_GEOG_20190418
 geogrid_exe: '{HOME}/openmethane-beta/wrf/coecms/WPS/geogrid.exe'


### PR DESCRIPTION
## Scope

Running setup-wrf on a new domain can take a very long time when FNL files have to be downloaded on each attempt. This adds a configuration option which, if present, makes a copy of downloaded FNL files in a central cache. FNL files are copied from this cache when present, instead of downloading.

This is particularly helpful during development, when the same time period is being run over many iterations.