### PR TITLE
Update domain store URL to S3 public data store

### DIFF
--- a/scripts/run-wrf.sh
+++ b/scripts/run-wrf.sh
@@ -50,7 +50,7 @@ fi
 # Try fetch the published domain
 # If the domain isn't available it will be created by setup_for_wrf.py
 wget -N -nv -P ${STORE_PATH}/wrf/${DOMAIN_NAME} \
-  https://prior.openmethane.org/domains/${DOMAIN_NAME}/${DOMAIN_VERSION}/geo_em.d01.nc \
+  "https://openmethane.s3.amazonaws.com/domains/${DOMAIN_NAME}/${DOMAIN_VERSION}/geo_em.d01.nc" \
   || echo "Domain file not found, will create it"
 
 # Steps of interest


### PR DESCRIPTION
## Description

This replaces one of the last references to prior.openmethane.org (hosted on Cloudflare) with the S3 bucket that is our official public data store.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
