### PR TITLE
Fix dev version bump to also include patch in release GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
 
           # Bump to pre-release so that future commits do not have the same
           # version as the tagged commit
-          NEXT_VERSION=`uv version --short dev`
+          NEXT_VERSION=`uv version --short --bump patch --bump dev`
           echo "Bumping version $NEW_VERSION > $NEXT_VERSION"
           git commit -a -m "bump(pre-release): version $NEW_VERSION > $NEXT_VERSION"
           git push && git push --tags


### PR DESCRIPTION

## Description

Similar to https://github.com/openmethane/openmethane/pull/187.

Bumping only `dev` results in a change like `0.2.0` -> `0.2.0.dev1` which uv considers a "backwards" version increment. By also bumping the `patch` version, this results in `0.2.0` -> `0.2.1.dev1`, which is allowed.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
