### PR TITLE
Allow docker to use all cores when NCPUS_ALL=true

### DIFF
--- a/targets/docker/run_script_template.sh
+++ b/targets/docker/run_script_template.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-export NCPUS=${NCPUS:-1}
+## specify NCPUS_ALL=true to utilise all cores
+NCPUS_DEFAULT=1
+if [ "$NCPUS_ALL" = "true" ]; then
+  NCPUS_DEFAULT=`nproc --all`
+fi
+
+## if NCPUS is specified, it always overrides NCPUS_ALL
+export NCPUS=${NCPUS:-$NCPUS_DEFAULT}
 
 cd ${RUN_DIR} || exit 1
 


### PR DESCRIPTION

## Description

Add the `NCPUS_ALL`  env var to allow WRF to use all available cores when the number of cores isn't known in advance, ie in AWS.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
