### PR TITLE
Allow FNL download root to be set via FNL_DATASET_ROOT env var

### DIFF
--- a/changelog/78.improvement.md
+++ b/changelog/78.improvement.md
@@ -1,0 +1,1 @@
+Allow using an alternate FNL file mirror by setting the `FNL_DATASET_ROOT` env var

--- a/src/setup_runs/wrf/fetch_fnl.py
+++ b/src/setup_runs/wrf/fetch_fnl.py
@@ -22,9 +22,12 @@ from urllib3.util import Retry
 
 N_JOBS = 8
 
-DATASET_URL = "https://tds.gdex.ucar.edu/thredds/fileServer/files/g/d083003/" # THREDDS
+FNL_DATASET_ROOT = "https://tds.gdex.ucar.edu/thredds/fileServer/files/g/d083003/" # THREDDS
+if "FNL_DATASET_ROOT" in os.environ and os.environ["FNL_DATASET_ROOT"] is not None:
+    FNL_DATASET_ROOT = os.environ["FNL_DATASET_ROOT"]
+
 # Backup data source
-# DATASET_URL = "https://osdf-data.gdex.ucar.edu/ncar/gdex/d083003/" # OSDF
+# FNL_DATASET_ROOT = "https://osdf-data.gdex.ucar.edu/ncar/gdex/d083003/" # OSDF
 
 FNL_START_DATE = pytz.UTC.localize(datetime.datetime(2015, 7, 8, 0, 0, 0))
 
@@ -145,7 +148,7 @@ def download_gdas_fnl_data(
     downloaded_files = list(
         tqdm(
             Parallel(return_as="generator", n_jobs=N_JOBS)(
-                delayed(download_file)(session, target_dir, DATASET_URL + filename)
+                delayed(download_file)(session, target_dir, FNL_DATASET_ROOT + filename)
                 for filename in file_list
             ),
             total=len(file_list),

--- a/src/setup_runs/wrf/fetch_fnl.py
+++ b/src/setup_runs/wrf/fetch_fnl.py
@@ -22,12 +22,13 @@ from urllib3.util import Retry
 
 N_JOBS = 8
 
-FNL_DATASET_ROOT = "https://tds.gdex.ucar.edu/thredds/fileServer/files/g/d083003/" # THREDDS
+FNL_DATASET_ROOT = "https://data.gdex.ucar.edu/d083003/"
 if "FNL_DATASET_ROOT" in os.environ and os.environ["FNL_DATASET_ROOT"] is not None:
     FNL_DATASET_ROOT = os.environ["FNL_DATASET_ROOT"]
 
 # Backup data source
-# FNL_DATASET_ROOT = "https://osdf-data.gdex.ucar.edu/ncar/gdex/d083003/" # OSDF
+# THREDDS now requires authentication for fileServer access
+# FNL_DATASET_ROOT = "https://tds.gdex.ucar.edu/thredds/fileServer/files/g/d083003/" # THREDDS
 
 FNL_START_DATE = pytz.UTC.localize(datetime.datetime(2015, 7, 8, 0, 0, 0))
 


### PR DESCRIPTION
## Description

The FNL dataset provider is one of the least reliable of all the data sources used in Open Methane. It frequently drops connections, sometimes going down entirely due to outage or mis-configuration.

This will allow us to switch to a different dataset mirror by updating the `FNL_DATASET_ROOT` env var without having to make a code change, cut a `setup-wrf` release and a build a new image.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
