### PR TITLE
Use `openmethane/wrf` image instead of `climate-resource/wrf`

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -65,7 +65,7 @@ jobs:
           labels: |
             org.opencontainers.image.title="Setup WRF"
             org.opencontainers.image.description="Generate the scripts needed to run WRF according to configuration"
-            org.opencontainers.image.authors="Jared Lewis <jared.lewis@climate-resource.com>, Jeremy Silver <jeremy.silver@unimelb.edu.au>"
+            org.opencontainers.image.authors="Lindsay Gaines <lindsay.gaines@superpowerinstitute.com.au>, Jeremy Silver <jeremy.silver@unimelb.edu.au>"
             org.opencontainers.image.vendor="The Superpower Institute"
 
       - name: Build and push image

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,13 +44,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --active
 
 # Then, use a final image without uv for our runtime environment
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # These will be overwritten in GHA due to https://github.com/docker/metadata-action/issues/295
 # These must be duplicated in .github/workflows/build_docker.yaml
 LABEL org.opencontainers.image.title="Setup WRF"
 LABEL org.opencontainers.image.description="Generate the scripts needed to run WRF according to configuration"
-LABEL org.opencontainers.image.authors="Jared Lewis <jared.lewis@climate-resource.com>, Jeremy Silver <jeremy.silver@unimelb.edu.au>"
+LABEL org.opencontainers.image.authors="Lindsay Gaines <lindsay.gaines@superpowerinstitute.com.au>, Jeremy Silver <jeremy.silver@unimelb.edu.au>"
 LABEL org.opencontainers.image.vendor="The Superpower Institute"
 
 # SETUP_WRF_VERSION will be overridden in release builds with semver vX.Y.Z
@@ -101,8 +101,8 @@ COPY --from=chamber /chamber /bin/chamber
 COPY --from=builder /opt/venv /opt/venv
 
 # Copy in the WRF binaries
-# https://github.com/climate-resource/docker-wrf
-COPY --from=ghcr.io/climate-resource/wrf:4.5.1 /opt/wrf /opt/wrf
+# https://github.com/openmethane/docker-wrf
+COPY --from=ghcr.io/openmethane/wrf:4.5.1 /opt/wrf /opt/wrf
 
 # Copy the application from the builder
 COPY --from=builder --chown=nonroot:nonroot /opt/project /opt/project

--- a/changelog/80.improvement.md
+++ b/changelog/80.improvement.md
@@ -1,0 +1,1 @@
+Use openmethane/wrf base image instead of climate-resource/wrf

--- a/docs/required_software.md
+++ b/docs/required_software.md
@@ -6,11 +6,11 @@ These packages are installed in different ways,
 but are all brought together in a Docker container (see [../Dockerfile]())
 The following table lists the software and versions that are required to run the workflow.
 
-| Software | Version | Installation Method                                   |
-|----------|---------|-------------------------------------------------------|
-| Python   | 3.11    | docker container                                      |
-| WRF      | 4.5.1   | docker container (ghcr.io/climate-resource/wrf:4.5.1) |
-| wgrib2   | 2.0.8   | conda                                                 |
-| csh      | *       | conda                                                 |
-| mpich    | 4.2.1   | conda                                                 |
-| NCO      | *       | conda                                                 |
+| Software | Version | Installation Method                              |
+|----------|---------|--------------------------------------------------|
+| Python   | 3.11    | docker container                                 |
+| WRF      | 4.5.1   | docker container (ghcr.io/openmethane/wrf:4.5.1) |
+| wgrib2   | 2.0.8   | conda                                            |
+| csh      | *       | conda                                            |
+| mpich    | 4.2.1   | conda                                            |
+| NCO      | *       | conda                                            |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "setup_runs"
 version = "0.7.5.dev1"
 description = "Scripts for running WRF "
 authors = [
+    { name = "Lindsay Gaines", email = "lindsay.gaines@superpowerinstitute.com.au" },
     { name = "Peter Rayner", email = "peter.rayner@superpowerinstitute.com.au" },
     { name = "Jeremy Silver" },
-    { name = "Jared Lewis", email = "jared.lewis@climate-resource.com" },
 ]
 requires-python = ">=3.10,<4,<3.12"
 readme = "README.md"


### PR DESCRIPTION
## Description

The `openmethane/wrf` image (from https://github.com/openmethane/docker-wrf) is a fork of https://github.com/climate-resource/docker-wrf. Climate Resource have stated that they don't plan to use their docker-wrf repo in the future, so it will be easier for us to maintain and make changes to our own fork.

Immediately this means updating our base image to debian trixie to work with the glibc versions from docker-wrf, which uses a build image based on trixie.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
